### PR TITLE
Addition of source IP interface

### DIFF
--- a/pam_tacplus.c
+++ b/pam_tacplus.c
@@ -186,7 +186,7 @@ int _pam_account(pam_handle_t *pamh, int argc, const char **argv, int type,
 	status = PAM_SESSION_ERR;
 	for (srv_i = 0; srv_i < tac_srv_no; srv_i++) {
 		tac_fd = tac_connect_single(tac_srv[srv_i].addr, tac_srv[srv_i].key,
-				NULL, tac_timeout);
+				tac_src_addr_info, tac_timeout);
 		if (tac_fd < 0) {
 			_pam_log(LOG_WARNING, "%s: error sending %s (fd)", __FUNCTION__,
 					typemsg);
@@ -287,7 +287,7 @@ int pam_sm_authenticate(pam_handle_t * pamh, int flags, int argc,
 			syslog(LOG_DEBUG, "%s: trying srv %d", __FUNCTION__, srv_i);
 
 		tac_fd = tac_connect_single(tac_srv[srv_i].addr, tac_srv[srv_i].key,
-				NULL, tac_timeout);
+				tac_src_addr_info, tac_timeout);
 		if (tac_fd < 0) {
 			_pam_log(LOG_ERR, "connection failed srv %d: %m", srv_i);
 			active_server.addr = NULL;
@@ -607,8 +607,8 @@ int pam_sm_acct_mgmt(pam_handle_t * pamh, int flags, int argc,
 	if (tac_protocol[0] != '\0')
 		tac_add_attrib(&attr, "protocol", tac_protocol);
 
-	tac_fd = tac_connect_single(active_server.addr, active_server.key, NULL,
-			tac_timeout);
+	tac_fd = tac_connect_single(active_server.addr, active_server.key,
+			tac_src_addr_info, tac_timeout);
 	if (tac_fd < 0) {
 		_pam_log(LOG_ERR, "TACACS+ server unavailable");
 		if (arep.msg != NULL)
@@ -801,7 +801,7 @@ int pam_sm_chauthtok(pam_handle_t * pamh, int flags, int argc,
 			syslog(LOG_DEBUG, "%s: trying srv %d", __FUNCTION__, srv_i);
 
 		tac_fd = tac_connect_single(tac_srv[srv_i].addr, tac_srv[srv_i].key,
-				NULL, tac_timeout);
+				tac_src_addr_info, tac_timeout);
 		if (tac_fd < 0) {
 			_pam_log(LOG_ERR, "connection failed srv %d: %m", srv_i);
 			continue;

--- a/support.h
+++ b/support.h
@@ -39,6 +39,7 @@ extern int tac_srv_no;
 extern char tac_service[64];
 extern char tac_protocol[64];
 extern char tac_prompt[64];
+extern struct addrinfo *tac_src_addr_info;
 void tac_copy_addr_info (struct addrinfo *p_dst, const struct addrinfo *p_src);
 
 int _pam_parse (int, const char **);


### PR DESCRIPTION
This patch adds code in _pam_parse() to parse new option "source_ip" and stores
the converted address information in static memory. The address info is then
used when calling tac_connect_single().
    
Note: at this moment, the "source_ip" is an ipv4 address in dot-decimal notation.
It could be expanded to accept ip interface name and support ipv6.